### PR TITLE
Add 'utm_emailname' and 'utm_funnel' to blacklist

### DIFF
--- a/Clean Links Extension/SafariExtensionHandler.swift
+++ b/Clean Links Extension/SafariExtensionHandler.swift
@@ -20,6 +20,8 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
         "utm_campaign",
         "utm_term",
         "utm_content",
+        "utm_emailname",
+        "utm_funnel",
         "gclid",
         "gclsrc",
         "dclid",


### PR DESCRIPTION
Love the project!

I just saw both of these used in an email newsletter from Oculus, not sure if this is "normal" utm* stuff, Oculus specific or where that actually comes from, but I wanted to add them regardless.

Cheers ✌️ 